### PR TITLE
Fix build_test_publish.yml build step

### DIFF
--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -26,7 +26,7 @@ jobs:
           go-version: '1.x'
 
       - name: Build application
-        run: go build -o endpoint -o build/endpoint main.go
+        run: go build -o build/endpoint main.go
 
       - name: Test application
         run: go test ./...


### PR DESCRIPTION
## Description
This pull request updates the workflow file `build_test_publish.yml` by simplifying the "Build application" step command. The command `go build -o endpoint -o build/endpoint main.go` has been replaced with `go build -o build/endpoint main.go` to remove the unnecessary duplication. This modification aims to improve code readability and maintainability.

## Changes Made
- Replaced `go build -o endpoint -o build/endpoint main.go` with `go build -o build/endpoint main.go`.
