### PR TITLE
Split github actions workflow

### DIFF
--- a/.github/workflows/build_test_publish.yml
+++ b/.github/workflows/build_test_publish.yml
@@ -1,20 +1,13 @@
-name: Build & Test Application and Create & Publish Docker Image to Github Packages
+name: Build & Test Application
 
 on:
   push:
     branches:
       - main
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
-
 jobs:
   build-test-publish:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
 
     steps:
       - name: Checkout code
@@ -31,25 +24,5 @@ jobs:
       - name: Test application
         run: go test ./...
 
-      - name: Log in to the Container registry
-        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
 
 

--- a/.github/workflows/create_publish_docker.yml
+++ b/.github/workflows/create_publish_docker.yml
@@ -1,0 +1,48 @@
+name: Create & Publish Docker Image to Github Packages
+
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - main
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-publish:
+    if: github.ref_type == 'tag' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@65b78e6e13532edd9afa3aa52ac7964289d1a9c1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@9ec57ed1fcdbf14dcef7dfbe97b2010124a938b7
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+
+


### PR DESCRIPTION
## Description

This pull request splits the existing `build_test_publish.yml` file into two separate YAML files. The `build_test_publish.yml` workflow will now focus on building and testing the application, while the newly created `create_publish_docker.yml` workflow will handle the creation and publishing of a Docker image to GitHub Packages.

The purpose of this change is to trigger these workflows based on different events. The `build_test_publish.yml` workflow will continue to be triggered on a merge to the `main` branch. The `create_publish_docker.yml` workflow will now require two conditions for triggering: a merge to the `main` branch and the presence of a new Git tag.

## Changes Made

- Split the existing `build_test_publish.yml` workflow into two separate workflows: `build_test_publish.yml` and `create_publish_docker.yml`.
- The `build_test_publish.yml` workflow focuses on building and testing the application.
- The `create_publish_docker.yml` workflow handles the creation and publishing of a Docker image to GitHub Packages.
- The `build_test_publish.yml` workflow is triggered on a merge to the `main` branch.
- The `create_publish_docker.yml` workflow is triggered on a merge to the `main` branch, combined with the presence of a new Git tag.
